### PR TITLE
Replace System.lineSeparator() with \n for cross-platform consistency…

### DIFF
--- a/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/sqlbuilder/ddl/index/PostgreSQLIndexSQLGeneratorTest.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/sqlbuilder/ddl/index/PostgreSQLIndexSQLGeneratorTest.java
@@ -39,7 +39,7 @@ class PostgreSQLIndexSQLGeneratorTest {
         Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
         ResultSet getNodesResultSet = mockGetNodesResultSet();
         when(connection.createStatement().executeQuery(
-                contains("SELECT DISTINCT ON(cls.relname) cls.oid, cls.relname as name," + System.lineSeparator() + "(SELECT (CASE WHEN count(i.inhrelid) > 0 THEN true ELSE false END)")))
+                contains("SELECT DISTINCT ON(cls.relname) cls.oid, cls.relname as name," + "\n" + "(SELECT (CASE WHEN count(i.inhrelid) > 0 THEN true ELSE false END)")))
                         .thenReturn(getNodesResultSet);
         ResultSet getPropertiesResultSet = mockGetPropertiesResultSet();
         when(connection.createStatement().executeQuery(contains("SELECT DISTINCT ON(cls.relname) cls.oid, cls.relname as name, indrelid, indkey, indisclustered"))).thenReturn(getPropertiesResultSet);
@@ -50,8 +50,8 @@ class PostgreSQLIndexSQLGeneratorTest {
         context.put("schema", "foo_schema");
         context.put("name", "foo_tbl");
         String actual = new PostgreSQLIndexSQLGenerator(connection, 10, 0).generate(context);
-        String expected = "CREATE INDEX IF NOT EXISTS foo_tbl" + System.lineSeparator() + "ON foo_schema.foo_tbl USING foo_am_name"
-                + System.lineSeparator() + "()" + System.lineSeparator() + "WITH (FILLFACTOR=90)" + System.lineSeparator() + "TABLESPACE default" + System.lineSeparator() + "WHERE NULL;";
+        String expected = "CREATE INDEX IF NOT EXISTS foo_tbl" + "\n" + "ON foo_schema.foo_tbl USING foo_am_name"
+                + "\n" + "()" + "\n" + "WITH (FILLFACTOR=90)" + "\n" + "TABLESPACE default" + "\n" + "WHERE NULL;";
         assertThat(actual, is(expected));
     }
     

--- a/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/sqlbuilder/ddl/table/PostgreSQLTablePropertiesLoaderTest.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/sqlbuilder/ddl/table/PostgreSQLTablePropertiesLoaderTest.java
@@ -37,10 +37,10 @@ class PostgreSQLTablePropertiesLoaderTest {
         Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
         when(connection.getCatalog()).thenReturn("foo_db");
         ResultSet fetchDatabaseIdResultSet = mockFetchDatabaseIdResultSet();
-        when(connection.createStatement().executeQuery(System.lineSeparator() + "SELECT oid AS did, datlastsysoid FROM pg_catalog.pg_database WHERE datname = 'foo_db';" + System.lineSeparator()))
+        when(connection.createStatement().executeQuery("\n" + "SELECT oid AS did, datlastsysoid FROM pg_catalog.pg_database WHERE datname = 'foo_db';" + "\n"))
                 .thenReturn(fetchDatabaseIdResultSet);
         ResultSet fetchSchemaIdResultSet = mockFetchSchemaIdResultSet();
-        when(connection.createStatement().executeQuery(System.lineSeparator() + "SELECT oid AS scid FROM pg_catalog.pg_namespace WHERE nspname = 'foo_schema';" + System.lineSeparator()))
+        when(connection.createStatement().executeQuery("\n" + "SELECT oid AS scid FROM pg_catalog.pg_namespace WHERE nspname = 'foo_schema';" + "\n"))
                 .thenReturn(fetchSchemaIdResultSet);
         Map<String, Object> actual = new PostgreSQLTablePropertiesLoader(connection, "foo_tbl", "foo_schema", 12, 0).load();
         assertThat(actual.size(), is(7));

--- a/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/sqlbuilder/template/PostgreSQLPipelineFreemarkerManagerTest.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/sqlbuilder/template/PostgreSQLPipelineFreemarkerManagerTest.java
@@ -32,7 +32,7 @@ class PostgreSQLPipelineFreemarkerManagerTest {
     @Test
     void assertGetSQLByDefaultVersion() {
         String actual = PostgreSQLPipelineFreemarkerManager.getSQLByVersion(Collections.singletonMap("databaseName", "foo_db"), "component/table/%s/get_database_id.ftl", 10, 0);
-        String expected = System.lineSeparator() + "SELECT oid AS did, datlastsysoid FROM pg_catalog.pg_database WHERE datname = 'foo_db';" + System.lineSeparator();
+        String expected = "\n" + "SELECT oid AS did, datlastsysoid FROM pg_catalog.pg_database WHERE datname = 'foo_db';" + "\n";
         assertThat(actual, is(expected));
     }
     


### PR DESCRIPTION
Fixes #33789.

Changes proposed in this pull request:
  -To address this, I propose replacing System.lineSeparator() with "\n" to ensure consistency across platforms. Since .ftl and other text files in the repository use \n as the standard line separator, this change will ensure tests behave consistently regardless of the operating system.

---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [X] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
- [ ] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
