### PR TITLE
Issue #32280/ bug fix: WHERE segment with ON CONFLICT segment in INSERT throws exception

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -72,6 +72,7 @@
 1. Encrypt: Use sql bind info in EncryptInsertPredicateColumnTokenGenerator to avoid wrong column table mapping - [#34110](https://github.com/apache/shardingsphere/pull/34110)
 1. Mode: Fixes `JDBCRepository` improper handling of H2-database in memory mode - [#33281](https://github.com/apache/shardingsphere/issues/33281)
 1. Mode: Fixes duplicate column names added when index changed in DDL - [#33982](https://github.com/apache/shardingsphere/issues/33281)
+1. SQL Binder:  Fixes bug: throwing exception while using WHERE statement in ON CONFLICT with INSERT INTO in Postgres [#32280](https://github.com/apache/shardingsphere/issues/32280)
 
 ### Change Logs
 

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/insert/values/OnConflictUpdateContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/insert/values/OnConflictUpdateContext.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.context.segment.insert.values;
+
+import com.google.common.base.Preconditions;
+import lombok.Getter;
+import lombok.ToString;
+import org.apache.shardingsphere.infra.binder.context.type.WhereAvailable;
+import org.apache.shardingsphere.sql.parser.statement.core.extractor.ColumnExtractor;
+import org.apache.shardingsphere.sql.parser.statement.core.extractor.ExpressionExtractor;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.ColumnAssignmentSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.FunctionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Getter
+@ToString
+public final class OnConflictUpdateContext implements WhereAvailable {
+    
+    private final int parameterCount;
+    
+    private final List<ExpressionSegment> valueExpressions;
+    
+    private final Collection<WhereSegment> whereSegments = new LinkedList<>();
+    
+    private final Collection<ColumnSegment> columnSegments;
+    
+    private final Collection<BinaryOperationExpression> joinConditions = new LinkedList<>();
+    
+    private final List<ParameterMarkerExpressionSegment> parameterMarkerExpressions;
+    
+    private final List<Object> parameters;
+    
+    public OnConflictUpdateContext(final Collection<ColumnAssignmentSegment> assignments, final List<Object> params, final int parametersOffset, Optional<WhereSegment> segment) {
+        List<ExpressionSegment> expressionSegments = assignments.stream().map(ColumnAssignmentSegment::getValue).collect(Collectors.toList());
+        segment.ifPresent(whereSegments::add);
+        for (WhereSegment whereSegment : whereSegments) {
+            expressionSegments.add(whereSegment.getExpr());
+        }
+        columnSegments = assignments.stream().map(each -> each.getColumns().get(0)).collect(Collectors.toList());
+        ColumnExtractor.extractColumnSegments(columnSegments, whereSegments);
+        ExpressionExtractor.extractJoinConditions(joinConditions, whereSegments);
+        valueExpressions = getValueExpressions(expressionSegments);
+        parameterMarkerExpressions = ExpressionExtractor.getParameterMarkerExpressions(expressionSegments);
+        parameterCount = parameterMarkerExpressions.size();
+        parameters = getParameters(params, parametersOffset);
+    }
+    
+    private List<ExpressionSegment> getValueExpressions(final Collection<ExpressionSegment> assignments) {
+        List<ExpressionSegment> result = new ArrayList<>(assignments.size());
+        result.addAll(assignments);
+        return result;
+    }
+    
+    private List<Object> getParameters(final List<Object> params, final int paramsOffset) {
+        if (params.isEmpty() || 0 == parameterCount) {
+            return Collections.emptyList();
+        }
+        List<Object> result = new ArrayList<>(parameterCount);
+        result.addAll(params.subList(paramsOffset, paramsOffset + parameterCount));
+        return result;
+    }
+    
+    /**
+     * Get value.
+     *
+     * @param index index
+     * @return value
+     */
+    public Object getValue(final int index) {
+        ExpressionSegment valueExpression = valueExpressions.get(index);
+        if (valueExpression instanceof ParameterMarkerExpressionSegment) {
+            return parameters.get(getParameterIndex((ParameterMarkerExpressionSegment) valueExpression));
+        }
+        if (valueExpression instanceof FunctionSegment) {
+            return valueExpression;
+        }
+        return ((LiteralExpressionSegment) valueExpression).getLiterals();
+    }
+    
+    private int getParameterIndex(final ParameterMarkerExpressionSegment paramMarkerExpression) {
+        int result = parameterMarkerExpressions.indexOf(paramMarkerExpression);
+        Preconditions.checkArgument(result >= 0, "Can not get parameter index.");
+        return result;
+    }
+}

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/InsertStatementBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/statement/dml/InsertStatementBinder.java
@@ -32,6 +32,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.Co
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.InsertStatement;
+import org.apache.shardingsphere.sql.parser.statement.postgresql.dml.PostgreSQLInsertStatement;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -63,6 +64,12 @@ public final class InsertStatementBinder implements SQLStatementBinder<InsertSta
         result.getValues().addAll(sqlStatement.getValues());
         sqlStatement.getSetAssignment().ifPresent(result::setSetAssignment);
         sqlStatement.getOnDuplicateKeyColumns().ifPresent(result::setOnDuplicateKeyColumns);
+        sqlStatement.getOnConflictKeyColumns().ifPresent(segment -> {
+            if (result instanceof PostgreSQLInsertStatement) {
+                ((PostgreSQLInsertStatement) result).setOnConflictKeyColumnsSegment(segment);
+            }
+        });
+        sqlStatement.getWithSegment().ifPresent(result::setWithSegment);
         sqlStatement.getOutputSegment().ifPresent(result::setOutputSegment);
         sqlStatement.getMultiTableInsertType().ifPresent(result::setMultiTableInsertType);
         sqlStatement.getMultiTableInsertIntoSegment().ifPresent(result::setMultiTableInsertIntoSegment);

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/insert/values/OnConflictUpdateContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/insert/values/OnConflictUpdateContextTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.context.segment.insert.values;
+
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.ColumnAssignmentSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.simple.SimpleExpressionSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.value.identifier.IdentifierValue;
+import org.junit.jupiter.api.Test;
+import org.mockito.internal.configuration.plugins.Plugins;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class OnConflictUpdateContextTest {
+    
+    @Test
+    void assertInstanceConstructedOk() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        OnConflictUpdateContext onConflictUpdateContext = new OnConflictUpdateContext(Collections.emptyList(), Collections.emptyList(), 0, Optional.empty());
+        assertThat(onConflictUpdateContext.getValueExpressions(), is(Plugins.getMemberAccessor()
+                .invoke(OnConflictUpdateContext.class.getDeclaredMethod("getValueExpressions", Collection.class), onConflictUpdateContext, Collections.emptyList())));
+        assertThat(onConflictUpdateContext.getParameters(), is(Plugins.getMemberAccessor()
+                .invoke(OnConflictUpdateContext.class.getDeclaredMethod("getParameters", List.class, int.class), onConflictUpdateContext, Collections.emptyList(), 0)));
+    }
+    
+    @Test
+    void assertConstructorWithValidInputAndWhereSegment() {
+        List<ColumnAssignmentSegment> assignments = Collections.singletonList(
+                createAssignmentSegment(new LiteralExpressionSegment(0, 10, "literalValue")));
+        WhereSegment whereSegment = new WhereSegment(0, 10, new LiteralExpressionSegment(0, 10, "whereCondition"));
+        OnConflictUpdateContext context = new OnConflictUpdateContext(assignments, Arrays.asList("param1", "param2"), 0, Optional.of(whereSegment));
+        assertThat(context.getValueExpressions().size(), is(2));
+        assertThat(context.getParameters().size(), is(0));
+        assertThat(context.getWhereSegments().size(), is(1));
+        assertThat(context.getColumnSegments().size(), is(1));
+    }
+    
+    @Test
+    void assertConstructorWithMultipleExpressionTypes() {
+        List<ColumnAssignmentSegment> assignments = Arrays.asList(
+                createAssignmentSegment(new ParameterMarkerExpressionSegment(0, 10, 0)),
+                createAssignmentSegment(new LiteralExpressionSegment(0, 10, "literalValue")));
+        
+        OnConflictUpdateContext context = new OnConflictUpdateContext(assignments, Arrays.asList("param1", "param2"), 0, Optional.empty());
+        
+        assertThat(context.getValueExpressions().size(), is(2));
+        assertThat(context.getParameters().size(), is(1)); // Only one parameter marker
+        assertThat(context.getParameters().get(0), is("param1"));
+    }
+    
+    @Test
+    void assertConstructorWithNoWhereSegment() {
+        List<ColumnAssignmentSegment> assignments = Collections.singletonList(
+                createAssignmentSegment(new LiteralExpressionSegment(0, 10, "literalValue")));
+        OnConflictUpdateContext context = new OnConflictUpdateContext(assignments, Collections.emptyList(), 0, Optional.empty());
+        assertThat(context.getValueExpressions().size(), is(1));
+        assertThat(context.getParameters().isEmpty(), is(true));
+    }
+    
+    @Test
+    void assertGetValueWhenParameterMarker() {
+        Collection<ColumnAssignmentSegment> assignments = createParameterMarkerExpressionAssignmentSegment();
+        String parameterValue1 = "test1";
+        String parameterValue2 = "test2";
+        List<Object> params = Arrays.asList(parameterValue1, parameterValue2);
+        OnConflictUpdateContext onConflictUpdateContext = new OnConflictUpdateContext(assignments, params, 0, Optional.empty());
+        Object valueFromInsertValueContext1 = onConflictUpdateContext.getValue(0);
+        assertThat(valueFromInsertValueContext1, is(parameterValue1));
+        Object valueFromInsertValueContext2 = onConflictUpdateContext.getValue(1);
+        assertThat(valueFromInsertValueContext2, is(parameterValue2));
+    }
+    
+    private Collection<ColumnAssignmentSegment> createParameterMarkerExpressionAssignmentSegment() {
+        ParameterMarkerExpressionSegment parameterMarkerExpressionSegment0 = new ParameterMarkerExpressionSegment(0, 10, 5);
+        ColumnAssignmentSegment assignmentSegment1 = createAssignmentSegment(parameterMarkerExpressionSegment0);
+        ParameterMarkerExpressionSegment parameterMarkerExpressionSegment1 = new ParameterMarkerExpressionSegment(0, 10, 6);
+        ColumnAssignmentSegment assignmentSegment2 = createAssignmentSegment(parameterMarkerExpressionSegment1);
+        return Arrays.asList(assignmentSegment1, assignmentSegment2);
+    }
+    
+    @Test
+    void assertGetValueWhenLiteralExpressionSegment() {
+        Object literalObject = new Object();
+        Collection<ColumnAssignmentSegment> assignments = createLiteralExpressionSegment(literalObject);
+        OnConflictUpdateContext onConflictUpdateContext = new OnConflictUpdateContext(assignments, Collections.emptyList(), 0, Optional.empty());
+        Object valueFromInsertValueContext = onConflictUpdateContext.getValue(0);
+        assertThat(valueFromInsertValueContext, is(literalObject));
+    }
+    
+    private Collection<ColumnAssignmentSegment> createLiteralExpressionSegment(final Object literalObject) {
+        LiteralExpressionSegment parameterLiteralExpression = new LiteralExpressionSegment(0, 10, literalObject);
+        ColumnAssignmentSegment assignmentSegment = createAssignmentSegment(parameterLiteralExpression);
+        return Collections.singleton(assignmentSegment);
+    }
+    
+    private BinaryOperationExpression createBinaryOperationExpression() {
+        ExpressionSegment left = new ColumnSegment(0, 0, new IdentifierValue("columnNameStr"));
+        ExpressionSegment right = new ParameterMarkerExpressionSegment(0, 0, 0);
+        return new BinaryOperationExpression(0, 0, left, right, "=", "columnNameStr=?");
+    }
+    
+    private ColumnAssignmentSegment createAssignmentSegment(final SimpleExpressionSegment expressionSegment) {
+        List<ColumnSegment> columnSegments = Collections.singletonList(new ColumnSegment(0, 0, new IdentifierValue("columnNameStr")));
+        return new ColumnAssignmentSegment(0, 0, columnSegments, expressionSegment);
+    }
+    
+    private ColumnAssignmentSegment createAssignmentSegment(final BinaryOperationExpression binaryOperationExpression) {
+        List<ColumnSegment> columnSegments = Collections.singletonList(new ColumnSegment(0, 0, new IdentifierValue("columnNameStr")));
+        return new ColumnAssignmentSegment(0, 0, columnSegments, binaryOperationExpression);
+    }
+    
+    @Test
+    void assertParameterCount() {
+        List<ColumnAssignmentSegment> assignments = Arrays.asList(
+                createAssignmentSegment(createBinaryOperationExpression()),
+                createAssignmentSegment(new ParameterMarkerExpressionSegment(0, 10, 5)),
+                createAssignmentSegment(new LiteralExpressionSegment(0, 10, new Object())));
+        OnConflictUpdateContext onConflictUpdateContext = new OnConflictUpdateContext(assignments, Arrays.asList("1", "2"), 0, Optional.empty());
+        assertThat(onConflictUpdateContext.getParameterCount(), is(2));
+    }
+}

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/context/SQLRewriteContext.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/context/SQLRewriteContext.java
@@ -69,26 +69,17 @@ public final class SQLRewriteContext {
         if (!queryContext.getHintValueContext().isSkipSQLRewrite()) {
             addSQLTokenGenerators(new DefaultTokenGeneratorBuilder(sqlStatementContext).getSQLTokenGenerators());
         }
-        List<Object> genericParams =
-                (sqlStatementContext.getSqlStatement() instanceof PostgreSQLInsertStatement)
-                        ? ((InsertStatementContext) sqlStatementContext).getOnConflictKeyUpdateParameters()
-                        : ((InsertStatementContext) sqlStatementContext).getOnDuplicateKeyUpdateParameters();
-        parameterBuilder = containsInsertValues(sqlStatementContext)
-                ? new GroupedParameterBuilder(((InsertStatementContext) sqlStatementContext).getGroupedParameters(),
-                genericParams)
-                : new StandardParameterBuilder(parameters);
-        
-        //        if (sqlStatementContext.getSqlStatement() instanceof PostgreSQLInsertStatement) {
-        //            parameterBuilder = containsInsertValues(sqlStatementContext)
-        //                    ? new GroupedParameterBuilder(((InsertStatementContext) sqlStatementContext).getGroupedParameters(),
-        //                    ((InsertStatementContext) sqlStatementContext).getOnConflictKeyUpdateParameters())
-        //                    : new StandardParameterBuilder(parameters);
-        //        } else {
-        //            parameterBuilder = containsInsertValues(sqlStatementContext)
-        //                    ? new GroupedParameterBuilder(((InsertStatementContext) sqlStatementContext).getGroupedParameters(),
-        //                    ((InsertStatementContext) sqlStatementContext).getOnDuplicateKeyUpdateParameters())
-        //                    : new StandardParameterBuilder(parameters);
-        //        }
+        if (sqlStatementContext.getSqlStatement() instanceof PostgreSQLInsertStatement) {
+            parameterBuilder = containsInsertValues(sqlStatementContext)
+                    ? new GroupedParameterBuilder(((InsertStatementContext) sqlStatementContext).getGroupedParameters(),
+                    ((InsertStatementContext) sqlStatementContext).getOnConflictKeyUpdateParameters())
+                    : new StandardParameterBuilder(parameters);
+        } else{
+            parameterBuilder = containsInsertValues(sqlStatementContext)
+                    ? new GroupedParameterBuilder(((InsertStatementContext) sqlStatementContext).getGroupedParameters(),
+                    ((InsertStatementContext) sqlStatementContext).getOnDuplicateKeyUpdateParameters())
+                    : new StandardParameterBuilder(parameters);
+        }
     }
     
     private boolean containsInsertValues(final SQLStatementContext sqlStatementContext) {

--- a/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/context/SQLRewriteContext.java
+++ b/infra/rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/context/SQLRewriteContext.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.infra.rewrite.sql.token.common.generator.builde
 import org.apache.shardingsphere.infra.rewrite.sql.token.common.pojo.SQLToken;
 import org.apache.shardingsphere.infra.session.connection.ConnectionContext;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
+import org.apache.shardingsphere.sql.parser.statement.postgresql.dml.PostgreSQLInsertStatement;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -68,9 +69,26 @@ public final class SQLRewriteContext {
         if (!queryContext.getHintValueContext().isSkipSQLRewrite()) {
             addSQLTokenGenerators(new DefaultTokenGeneratorBuilder(sqlStatementContext).getSQLTokenGenerators());
         }
+        List<Object> genericParams =
+                (sqlStatementContext.getSqlStatement() instanceof PostgreSQLInsertStatement)
+                        ? ((InsertStatementContext) sqlStatementContext).getOnConflictKeyUpdateParameters()
+                        : ((InsertStatementContext) sqlStatementContext).getOnDuplicateKeyUpdateParameters();
         parameterBuilder = containsInsertValues(sqlStatementContext)
-                ? new GroupedParameterBuilder(((InsertStatementContext) sqlStatementContext).getGroupedParameters(), ((InsertStatementContext) sqlStatementContext).getOnDuplicateKeyUpdateParameters())
+                ? new GroupedParameterBuilder(((InsertStatementContext) sqlStatementContext).getGroupedParameters(),
+                genericParams)
                 : new StandardParameterBuilder(parameters);
+        
+        //        if (sqlStatementContext.getSqlStatement() instanceof PostgreSQLInsertStatement) {
+        //            parameterBuilder = containsInsertValues(sqlStatementContext)
+        //                    ? new GroupedParameterBuilder(((InsertStatementContext) sqlStatementContext).getGroupedParameters(),
+        //                    ((InsertStatementContext) sqlStatementContext).getOnConflictKeyUpdateParameters())
+        //                    : new StandardParameterBuilder(parameters);
+        //        } else {
+        //            parameterBuilder = containsInsertValues(sqlStatementContext)
+        //                    ? new GroupedParameterBuilder(((InsertStatementContext) sqlStatementContext).getGroupedParameters(),
+        //                    ((InsertStatementContext) sqlStatementContext).getOnDuplicateKeyUpdateParameters())
+        //                    : new StandardParameterBuilder(parameters);
+        //        }
     }
     
     private boolean containsInsertValues(final SQLStatementContext sqlStatementContext) {

--- a/parser/sql/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
+++ b/parser/sql/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
@@ -131,6 +131,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignmen
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.SetAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.InsertColumnsSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.OnConflictKeyColumnsSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.OnDuplicateKeyColumnsSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.combine.CombineSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BetweenExpression;
@@ -704,7 +705,7 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
         PostgreSQLInsertStatement result = (PostgreSQLInsertStatement) visit(ctx.insertRest());
         result.setTable((SimpleTableSegment) visit(ctx.insertTarget()));
         if (null != ctx.optOnConflict()) {
-            result.setOnDuplicateKeyColumnsSegment((OnDuplicateKeyColumnsSegment) visit(ctx.optOnConflict()));
+            result.setOnConflictKeyColumnsSegment((OnConflictKeyColumnsSegment) visit(ctx.optOnConflict()));
         }
         if (null != ctx.returningClause()) {
             result.setReturningSegment((ReturningSegment) visit(ctx.returningClause()));
@@ -719,7 +720,11 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
         if (null != ctx.setClauseList()) {
             assignments = ((SetAssignmentSegment) visit(ctx.setClauseList())).getAssignments();
         }
-        return new OnDuplicateKeyColumnsSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), assignments);
+        WhereSegment whereSegment =
+                ctx.whereClause() != null
+                        ? new WhereSegment(ctx.whereClause().getStart().getStartIndex(), ctx.whereClause().getStop().getStopIndex(), (ExpressionSegment) visit(ctx.whereClause().aExpr()))
+                        : null;
+        return new OnConflictKeyColumnsSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), assignments, whereSegment);
     }
     
     @Override

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/column/OnConflictKeyColumnsSegment.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/segment/dml/column/OnConflictKeyColumnsSegment.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.SQLSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.ColumnAssignmentSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
+
+import java.util.Collection;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Getter
+public final class OnConflictKeyColumnsSegment implements SQLSegment {
+    
+    private final int startIndex;
+    
+    private final int stopIndex;
+    
+    private final Collection<ColumnAssignmentSegment> columns;
+    
+    private final WhereSegment where;
+    
+    /**
+     * Get where.
+     *
+     * @return where segment
+     */
+    public Optional<WhereSegment> getWhere() {
+        return Optional.ofNullable(where);
+    }
+}

--- a/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/dml/InsertStatement.java
+++ b/parser/sql/statement/core/src/main/java/org/apache/shardingsphere/sql/parser/statement/core/statement/dml/InsertStatement.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignmen
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.SetAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.InsertColumnsSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.OnConflictKeyColumnsSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.OnDuplicateKeyColumnsSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.exec.ExecSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.FunctionSegment;
@@ -102,6 +103,15 @@ public abstract class InsertStatement extends AbstractSQLStatement implements DM
      * @return on duplicate key columns segment
      */
     public Optional<OnDuplicateKeyColumnsSegment> getOnDuplicateKeyColumns() {
+        return Optional.empty();
+    }
+    
+    /**
+     * Get On conflict key columns segment.
+     *
+     * @return on conflict key columns segment
+     */
+    public Optional<OnConflictKeyColumnsSegment> getOnConflictKeyColumns() {
         return Optional.empty();
     }
     

--- a/parser/sql/statement/core/src/test/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/TableExtractorTest.java
+++ b/parser/sql/statement/core/src/test/java/org/apache/shardingsphere/sql/parser/statement/core/extractor/TableExtractorTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.routine.R
 import org.apache.shardingsphere.sql.parser.statement.core.segment.ddl.routine.ValidStatementSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.assignment.ColumnAssignmentSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.OnConflictKeyColumnsSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.OnDuplicateKeyColumnsSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.combine.CombineSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.expr.BinaryOperationExpression;
@@ -37,6 +38,7 @@ import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.Proj
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.item.SubqueryProjectionSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.LockSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.predicate.WhereSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.table.JoinTableSegment;
@@ -120,6 +122,8 @@ class TableExtractorTest {
         ColumnSegment columnSegment = new ColumnSegment(133, 136, new IdentifierValue("id"));
         columnSegment.setOwner(new OwnerSegment(130, 132, new IdentifierValue("t_order")));
         assignmentSegments.add(new ColumnAssignmentSegment(130, 140, Collections.singletonList(columnSegment), new LiteralExpressionSegment(141, 142, 1)));
+        WhereSegment segment = mock(WhereSegment.class);
+        when(insertStatement.getOnConflictKeyColumns()).thenReturn(Optional.of(new OnConflictKeyColumnsSegment(130, 140, assignmentSegments, segment)));
         when(insertStatement.getOnDuplicateKeyColumns()).thenReturn(Optional.of(new OnDuplicateKeyColumnsSegment(130, 140, assignmentSegments)));
         tableExtractor.extractTablesFromInsert(insertStatement);
         assertThat(tableExtractor.getRewriteTables().size(), is(2));

--- a/parser/sql/statement/type/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/statement/postgresql/dml/PostgreSQLInsertStatement.java
+++ b/parser/sql/statement/type/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/statement/postgresql/dml/PostgreSQLInsertStatement.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sql.parser.statement.postgresql.dml;
 
 import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.ReturningSegment;
+import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.OnConflictKeyColumnsSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.dml.column.OnDuplicateKeyColumnsSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.segment.generic.WithSegment;
 import org.apache.shardingsphere.sql.parser.statement.core.statement.dml.InsertStatement;
@@ -36,6 +37,8 @@ public final class PostgreSQLInsertStatement extends InsertStatement implements 
     
     private OnDuplicateKeyColumnsSegment onDuplicateKeyColumnsSegment;
     
+    private OnConflictKeyColumnsSegment onConflictKeyColumnsSegment;
+    
     private ReturningSegment returningSegment;
     
     @Override
@@ -46,6 +49,10 @@ public final class PostgreSQLInsertStatement extends InsertStatement implements 
     @Override
     public Optional<OnDuplicateKeyColumnsSegment> getOnDuplicateKeyColumns() {
         return Optional.ofNullable(onDuplicateKeyColumnsSegment);
+    }
+    @Override
+    public Optional<OnConflictKeyColumnsSegment> getOnConflictKeyColumns() {
+        return Optional.ofNullable(onConflictKeyColumnsSegment);
     }
     
     @Override


### PR DESCRIPTION
…ement of postgres

Fixes #32280

Changes proposed in this pull request:
  - Added flow for `whereSegment ` in `onConflictKeyColumnSegment ` which was missing and required. The current flow is more intent on the `on_duplicate` of MySQL than `on_conflict ` in Postgres which has been added in Postgres after Postgres 9.
 - While using ON CONFLICT with INSERT INTO statement in Postgres it was throwing an exception (no value specified for parameter) as it was not able to set the flow for where statement present in the `optOnConflict` rule which was eventually failing to read parameter markers expressions and assignments  present in `whereSegment`
 - This fix resolves the error and ensures the successful execution of the `INSERT INTO` statement. The flow for ON DUPLICATE has not been removed or altered for now, as It may be useful for certain conditions of older versions of Postgres (and can be deprecated in future if no use case is observed for long)
---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [X] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [X] I have added corresponding unit tests for my changes.
- [X] I have updated the Release Notes of the current development version. For more details, see [Update Release Note](https://shardingsphere.apache.org/community/en/involved/contribute/contributor/)
